### PR TITLE
Fix bugs with window minimisation on XFCE

### DIFF
--- a/src/main/java/taskmanager/ui/TaskManager.java
+++ b/src/main/java/taskmanager/ui/TaskManager.java
@@ -231,9 +231,9 @@ public class TaskManager extends JFrame implements InformationUpdateCallback, Pr
 	@Override
 	public void focus() {
 		if ((getExtendedState() & JFrame.ICONIFIED) != 0) {
+			setVisible(true);
 			setExtendedState(getExtendedState() & ~JFrame.ICONIFIED);
 			Config.put(Config.KEY_LAST_EXTENDED_STATE, "" + getExtendedState());
-			setVisible(true);
 		}
 		toFront();
 	}
@@ -316,7 +316,12 @@ public class TaskManager extends JFrame implements InformationUpdateCallback, Pr
 		@Override
 		public void windowStateChanged(WindowEvent e) {
 			Config.put(Config.KEY_LAST_EXTENDED_STATE, "" + e.getNewState());
-			setVisible(!shouldMinimizeToTray(e.getNewState()));
+			
+			if (shouldMinimizeToTray(e.getNewState())) {
+				setVisible(false);
+			} else if (!isVisible()) {
+				setVisible(true);
+			}
 		}
 	};
 


### PR DESCRIPTION
This PR fixes two bugs with window minimisation on (Manjaro) XFCE.

1. If "minimise to tray" was off, the window would immediately be restored after being minimised.
    Fixed by ensuring `setVisible(true)` is not called after minimisation if the window is still visible. Presumably, `setVisible(true)` un-minimises already visible windows (at least on XFCE)?
2. If "minimise to tray" was on, the window would be re-minimised and hidden immediately after clicking on the tray icon.
    Fixed by making the window visible _before_ changing the window state from minimised to normal. Presumably, XFCE/XFWM does not allow state changes to happen to a hidden window and that causes some weird de-sync of the window state, triggering a new "state changed to iconified" event?
    Unfortunately, this fix means that the window will open as minimised for a split second before being restored to a normal state.